### PR TITLE
[MM-18656] Use WKWebView over UIWebView

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -427,6 +427,19 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     p.resolve(providersAvailability);
   }
 
+  @ReactMethod
+  public void getUserAgent(Promise p) {
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        p.resolve(WebSettings.getDefaultUserAgent(getReactApplicationContext()));
+      } else {
+        p.resolve(System.getProperty("http.agent"));
+      }
+    } catch (RuntimeException e) {
+      p.resolve(System.getProperty("http.agent"));
+    }
+  }
+
   public String getInstallReferrer() {
     SharedPreferences sharedPref = getReactApplicationContext().getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
     return sharedPref.getString("installReferrer", null);
@@ -501,15 +514,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("uniqueId", Settings.Secure.getString(this.reactContext.getContentResolver(), Settings.Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);
-    try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-        constants.put("userAgent", WebSettings.getDefaultUserAgent(this.reactContext));
-      } else {
-        constants.put("userAgent", System.getProperty("http.agent"));
-      }
-    } catch (RuntimeException e) {
-      constants.put("userAgent", System.getProperty("http.agent"));
-    }
     constants.put("timezone", TimeZone.getDefault().getID());
     constants.put("isEmulator", this.isEmulator());
     constants.put("isTablet", this.isTablet());
@@ -597,7 +601,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("uniqueId", preferences.getString("uniqueId", ""));
     constants.put("systemManufacturer", preferences.getString("systemManufacturer", ""));
     constants.put("bundleId", preferences.getString("bundleId", ""));
-    constants.put("userAgent", preferences.getString("userAgent", ""));
     constants.put("timezone", preferences.getString("timezone", ""));
 
     constants.put("isEmulator", preferences.getBoolean("isEmulator", false));
@@ -682,7 +685,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("uniqueId", preferences.getString("uniqueId", ""));
     constants.put("systemManufacturer", preferences.getString("systemManufacturer", ""));
     constants.put("bundleId", preferences.getString("bundleId", ""));
-    constants.put("userAgent", preferences.getString("userAgent", ""));
 
     constants.put("isEmulator", preferences.getBoolean("isEmulator", false));
     constants.put("isTablet", preferences.getBoolean("isTablet", false));
@@ -729,7 +731,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     editor.putString("uniqueId", constants.get("uniqueId").toString());
     editor.putString("systemManufacturer", constants.get("systemManufacturer").toString());
     editor.putString("bundleId", constants.get("bundleId").toString());
-    editor.putString("userAgent", constants.get("userAgent").toString());
 
     editor.putBoolean("isEmulator", (Boolean) constants.get("isEmulator"));
     editor.putBoolean("isTablet", (Boolean) constants.get("isTablet"));

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -31,7 +31,7 @@ declare const _default: {
   getVersion: () => string;
   getReadableVersion: () => string;
   getDeviceName: () => string;
-  getUserAgent: () => string;
+  getUserAgent: () => Promise<string>;
   getDeviceLocale: () => string;
   getPreferredLocales: () => Array<string>;
   getDeviceCountry: () => string;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -401,8 +401,8 @@ export default {
   getDeviceName: function() {
     return RNDeviceInfo.deviceName;
   },
-  getUserAgent: function() {
-    return RNDeviceInfo.userAgent;
+  getUserAgent: async function() {
+    return RNDeviceInfo.getUserAgent();
   },
   getDeviceLocale: function() {
     return RNDeviceInfo.deviceLocale;

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -17,7 +17,7 @@ declare module.exports: {
   getVersion: () => string,
   getReadableVersion: () => string,
   getDeviceName: () => string,
-  getUserAgent: () => string,
+  getUserAgent: () => Promise<string>,
   getDeviceLocale: () => string,
   getPreferredLocales: () => Array<string>,
   getDeviceCountry: () => string,

--- a/example/App.js
+++ b/example/App.js
@@ -48,7 +48,7 @@ export default class App extends Component<Props> {
       deviceJSON.version = DeviceInfo.getVersion();
       deviceJSON.readableVersion = DeviceInfo.getReadableVersion();
       deviceJSON.deviceName = DeviceInfo.getDeviceName(); // needs android.permission.BLUETOOTH ?
-      deviceJSON.userAgent = DeviceInfo.getUserAgent();
+      deviceJSON.userAgent = await DeviceInfo.getUserAgent();
       deviceJSON.deviceLocale = DeviceInfo.getDeviceLocale();
       deviceJSON.preferredLocales = DeviceInfo.getPreferredLocales();
       deviceJSON.deviceCountry = DeviceInfo.getDeviceCountry();


### PR DESCRIPTION
`UIWebview` was used when getting the user agent. I applied the relevant changes from these two commits:

https://github.com/react-native-community/react-native-device-info/commit/34aecd604422ad127461f35713313d59596604ea

https://github.com/react-native-community/react-native-device-info/commit/c9033a6db0bcd3c0202a8b4f16b8822cacf32347

On our mobile app we'll just need to await `getUserAgent` in `app/init/fetch.js`. I've tested on Android and iOS and it's working fine.